### PR TITLE
Add readonly option support in instances.ini

### DIFF
--- a/modules_instance.py
+++ b/modules_instance.py
@@ -277,6 +277,7 @@ class ikaaro(instance):
     def start(self, readonly=False):
         path = self.options['path']
         cmd = '%s/icms-start.py -d %s' % (self.bin_icms, path)
+        readonly = readonly or self.options.get('readonly', False)
         if readonly:
             cmd = cmd + ' -r'
         host = self.get_host()


### PR DESCRIPTION
This allow to start/restart some instances with the -r option.
For example, it is useful to ensure an empty intance, used as static proxy,
is launched as readonly
